### PR TITLE
fix: beforeDestroy/destroyed mappings

### DIFF
--- a/src/plugins/vue-class-component/IntervalHook.ts
+++ b/src/plugins/vue-class-component/IntervalHook.ts
@@ -1,16 +1,17 @@
 import { ASTConverter, ASTResultKind, ReferenceKind } from '../types'
 import type ts from 'typescript'
-import { isInternalHook, copySyntheticComments } from '../../utils'
+import { isInternalHook, copySyntheticComments, getMappedHook } from '../../utils'
 
 export const convertIntervalHook: ASTConverter<ts.MethodDeclaration> = (node, options) => {
   const intervalHookName = node.name.getText()
 
   if (isInternalHook(intervalHookName)) {
     const tsModule = options.typescript
-    const removeIntervalHooks = ['created', 'beforeCreate']
-    const needNamedImports = [`on${intervalHookName.slice(0, 1).toUpperCase()}${intervalHookName.slice(1)}`]
-    if (removeIntervalHooks.includes(intervalHookName)) {
-      needNamedImports.splice(0, 1)
+    const namedImport = getMappedHook(intervalHookName)
+    const needNamedImports = []
+
+    if (namedImport) {
+      needNamedImports.push(namedImport)
     }
 
     const outputNode = (needNamedImports.length > 0)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,23 +42,28 @@ export function getDecoratorNames (tsModule: typeof ts, node: ts.Node): string[]
   return []
 }
 
+const $internalHooks = new Map<string, string | false>([
+  ['beforeCreate', false],
+  ['created', false],
+  ['beforeMount', 'onBeforeMount'],
+  ['mounted', 'onMounted'],
+  ['beforeDestroy', 'onBeforeUnmount'],
+  ['destroyed', 'onUnmounted'],
+  ['beforeUpdate', 'onBeforeUpdate'],
+  ['updated', 'onUpdated'],
+  ['activated', 'onActivated'],
+  ['deactivated', 'onDeactivated'],
+  ['render', 'onRender'],
+  ['errorCaptured', 'onErrorCaptured'], // 2.5
+  ['serverPrefetch', 'onServerPrefetch'] // 2.6
+])
+
 export function isInternalHook (methodName: string): boolean {
-  const $internalHooks = [
-    'beforeCreate',
-    'created',
-    'beforeMount',
-    'mounted',
-    'beforeDestroy',
-    'destroyed',
-    'beforeUpdate',
-    'updated',
-    'activated',
-    'deactivated',
-    'render',
-    'errorCaptured', // 2.5
-    'serverPrefetch' // 2.6
-  ]
-  return $internalHooks.includes(methodName)
+  return $internalHooks.has(methodName)
+}
+
+export function getMappedHook (methodName: string): string | undefined | false {
+  return $internalHooks.get(methodName)
 }
 
 export function isPrimitiveType (tsModule: typeof ts, returnType: ts.Type): boolean {

--- a/tests/__snapshots__/testTSFile.spec.ts.snap
+++ b/tests/__snapshots__/testTSFile.spec.ts.snap
@@ -6,6 +6,8 @@ exports[`testTSFile compatible 1`] = `
   reactive,
   toRefs,
   ref,
+  onBeforeUnmount,
+  onUnmounted,
   watch,
   onMounted,
   defineComponent
@@ -58,6 +60,13 @@ export default defineComponent({
       console.log(val, newVal)
     }
 
+    onBeforeUnmount(() => {
+      context.emit('tearing down')
+    })
+    onUnmounted(() => {
+      console.log('destroyed')
+    })
+
     const click = (c: string) => {
       context.emit('click', c)
     }
@@ -106,6 +115,8 @@ export default defineComponent({
       anotherComponent,
       msg,
       onMsgChanged,
+      onBeforeUnmount,
+      onUnmounted,
       click,
       value,
       checked,
@@ -126,6 +137,8 @@ exports[`testTSFile compatible and ts config file: stdout 1`] = `
   reactive,
   toRefs,
   ref,
+  onBeforeUnmount,
+  onUnmounted,
   watch,
   onMounted,
   defineComponent
@@ -178,6 +191,13 @@ export default defineComponent({
       console.log(val, newVal)
     }
 
+    onBeforeUnmount(() => {
+      ctx.emit('tearing down')
+    })
+    onUnmounted(() => {
+      console.log('destroyed')
+    })
+
     const click = (c: string) => {
       context.emit('click', c)
     }
@@ -226,6 +246,8 @@ export default defineComponent({
       anotherComponent,
       msg,
       onMsgChanged,
+      onBeforeUnmount,
+      onUnmounted,
       click,
       value,
       checked,
@@ -240,7 +262,16 @@ export default defineComponent({
 `;
 
 exports[`testTSFile no compatible 1`] = `
-"import { computed, reactive, toRefs, ref, watch, onMounted } from 'vue'
+"import {
+  computed,
+  reactive,
+  toRefs,
+  ref,
+  onBeforeUnmount,
+  onUnmounted,
+  watch,
+  onMounted
+} from 'vue'
 
 /**
  * My basic tag
@@ -288,6 +319,13 @@ export default {
     const onMsgChanged = (val: string, newVal: string) => {
       console.log(val, newVal)
     }
+
+    onBeforeUnmount(() => {
+      context.emit('tearing down')
+    })
+    onUnmounted(() => {
+      console.log('destroyed')
+    })
 
     const click = (c: string) => {
       context.emit('click', c)
@@ -337,6 +375,8 @@ export default {
       anotherComponent,
       msg,
       onMsgChanged,
+      onBeforeUnmount,
+      onUnmounted,
       click,
       value,
       checked,

--- a/tests/__snapshots__/testVueFile.spec.ts.snap
+++ b/tests/__snapshots__/testVueFile.spec.ts.snap
@@ -8,6 +8,8 @@ exports[`testVueFile compatible 1`] = `
   ref,
   provide,
   inject,
+  onBeforeUnmount,
+  onUnmounted,
   defineComponent
 } from '@vue/composition-api'
 
@@ -69,6 +71,13 @@ export default defineComponent({
      */
     const msg = ref('Vetur means \\"Winter\\" in icelandic.') //foo
 
+    onBeforeUnmount(() => {
+      context.emit('Tearing down')
+    })
+    onUnmounted(() => {
+      console.log('destroyed')
+    })
+
     /**
      * My greeting
      */
@@ -86,6 +95,8 @@ export default defineComponent({
       optional,
       bazi,
       msg,
+      onBeforeUnmount,
+      onUnmounted,
       hello
     }
   }
@@ -94,7 +105,16 @@ export default defineComponent({
 `;
 
 exports[`testVueFile no compatible 1`] = `
-"import { computed, reactive, toRefs, ref, provide, inject } from 'vue'
+"import {
+  computed,
+  reactive,
+  toRefs,
+  ref,
+  provide,
+  inject,
+  onBeforeUnmount,
+  onUnmounted
+} from 'vue'
 
 const symbol = Symbol('baz')
 
@@ -154,6 +174,13 @@ export default {
      */
     const msg = ref('Vetur means \\"Winter\\" in icelandic.') //foo
 
+    onBeforeUnmount(() => {
+      context.emit('Tearing down')
+    })
+    onUnmounted(() => {
+      console.log('destroyed')
+    })
+
     /**
      * My greeting
      */
@@ -171,6 +198,8 @@ export default {
       optional,
       bazi,
       msg,
+      onBeforeUnmount,
+      onUnmounted,
       hello
     }
   }

--- a/tests/fixture/Input.ts
+++ b/tests/fixture/Input.ts
@@ -63,6 +63,14 @@ export default class BasicPropertyClass extends Vue {
     this.removeItem()
   }
 
+  beforeDestroy() {
+    this.$emit('tearing down')
+  }
+
+  destroyed() {
+    console.log('destroyed')
+  }
+
   @Emit()
   click (c: string) {}
 

--- a/tests/fixture/Input.vue
+++ b/tests/fixture/Input.vue
@@ -57,5 +57,13 @@ export default class BasicPropertyClass extends Vue {
   hello () {
     console.log(this.msg)
   }
+
+  beforeDestroy() {
+    this.$emit('Tearing down');
+  }
+
+  destroyed() {
+    console.log('destroyed')
+  }
 }
 </script>


### PR DESCRIPTION
This fixes the mappings for `beforeDestroy` and `destroyed`, they should be `onBeforeUnmount` and `onUnmounted`.

Refactored how the mappings work so they it doesn't manipulate the string but just uses a Map. This slightly simplifies the `convertIntervalHook` function