### PR TITLE
feat: convert methods as function declaration

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -9,6 +9,7 @@ export interface Vc2cOptions {
   compatible: boolean
   setupPropsKey: string
   setupContextKey: string
+  useFunctionDeclaration: boolean
   typescript: typeof ts
   vueTemplateCompiler: typeof vueTemplateCompiler
   eslintConfigFile: string
@@ -24,6 +25,7 @@ export function getDefaultVc2cOptions (tsModule: typeof ts = ts): Vc2cOptions {
     compatible: false,
     setupPropsKey: 'props',
     setupContextKey: 'context',
+    useFunctionDeclaration: false,
     typescript: tsModule,
     vueTemplateCompiler: vueTemplateCompiler,
     eslintConfigFile: '.eslintrc.js',

--- a/src/plugins/vue-class-component/Method.ts
+++ b/src/plugins/vue-class-component/Method.ts
@@ -6,14 +6,9 @@ export const convertMethod: ASTConverter<ts.MethodDeclaration> = (node, options)
   const tsModule = options.typescript
   const methodName = node.name.getText()
 
-  const outputMethod = tsModule.createArrowFunction(
-    node.modifiers,
-    node.typeParameters,
-    node.parameters,
-    node.type,
-    tsModule.createToken(tsModule.SyntaxKind.EqualsGreaterThanToken),
-    node.body ?? tsModule.createBlock([])
-  )
+  const result = options.useFunctionDeclaration
+    ? convertMethodAsFunctionDeclaration(tsModule, node)
+    : convertMethodAsArrowFunction(tsModule, node)
 
   return {
     tag: 'Method',
@@ -24,19 +19,46 @@ export const convertMethod: ASTConverter<ts.MethodDeclaration> = (node, options)
     nodes: [
       copySyntheticComments(
         tsModule,
-        tsModule.createVariableStatement(
-          undefined,
-          tsModule.createVariableDeclarationList([
-            tsModule.createVariableDeclaration(
-              tsModule.createIdentifier(methodName),
-              undefined,
-              outputMethod
-            )
-          ],
-          tsModule.NodeFlags.Const)
-        ),
+        result,
         node
       )
     ] as ts.Statement[]
   }
+}
+
+const convertMethodAsFunctionDeclaration = (tsModule: typeof ts, node: ts.MethodDeclaration): ts.FunctionDeclaration => {
+  return tsModule.createFunctionDeclaration(
+    undefined,
+    undefined,
+    node.asteriskToken,
+    node.name.getText(),
+    node.typeParameters,
+    node.parameters,
+    node.type,
+    node.body ?? tsModule.createBlock([])
+  )
+}
+
+const convertMethodAsArrowFunction = (tsModule: typeof ts, node: ts.MethodDeclaration): ts.VariableStatement => {
+  const methodName = node.name.getText()
+  const outputMethod = tsModule.createArrowFunction(
+    undefined,
+    node.typeParameters,
+    node.parameters,
+    node.type,
+    tsModule.createToken(tsModule.SyntaxKind.EqualsGreaterThanToken),
+    node.body ?? tsModule.createBlock([])
+  )
+
+  return tsModule.createVariableStatement(
+    undefined,
+    tsModule.createVariableDeclarationList([
+      tsModule.createVariableDeclaration(
+        tsModule.createIdentifier(methodName),
+        undefined,
+        outputMethod
+      )
+    ],
+    tsModule.NodeFlags.Const)
+  )
 }


### PR DESCRIPTION
I've added functionality to convert methods as function declaration.

For example, this code:

```js
import Vue from 'vue'
import { Component } from 'vue-property-decorator'

@Component({})
export default class HelloWorld extends Vue {
  hello () {
    console.log('hello world')
  }
}
```

Will be converted into this:

```js
export default defineComponent({
  name: 'HelloWorld',
  setup(props, context) {
    function hello() {
      console.log('hello world')
    }
    return { hello }
  },
})
```

And fixed a bug with method modifiers.